### PR TITLE
fix(diagramlink): populate `positionFrom` and `positionTo`

### DIFF
--- a/src/DiagramModel.js
+++ b/src/DiagramModel.js
@@ -68,8 +68,8 @@ class DiagramModel {
       id: generateId(),
       from: from,
       to: to,
-      positionFrom: {},
-      positionTo: {},
+      positionFrom: { x: 0, y: 0 },
+      positionTo: { x: 0, y: 0 },
       points
     });
   }


### PR DESCRIPTION
with `{x:0, y:0}` in DiagramModel.addLink(). To prevent error message when new link is created. As the link's curve cannot otherwise be drawn properly (as no `x` nor `y` yet defined for `positionFrom` and `positionTo`) until the first call to `updateLinksPositions()`.

Close #6

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Code style update
- [ ] Feature
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch (or to a previous version branch), _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Problem was caused by DiagramModel.addLink() that was pushing a Link with empty `positionFrom` and `positionTo`.